### PR TITLE
Remove unused build-depends

### DIFF
--- a/build-tools/gen-META.p6
+++ b/build-tools/gen-META.p6
@@ -11,7 +11,6 @@ my $m = META6.new(
     perl-version   => Version.new('6.*'),
     depends        => [ ],
     test-depends   => <Test Test::META Test::When>,
-    build-depends  => <META6 p6doc Pod::To::Markdown>,
     tags           => <IP IPv4 IPv6>,
     authors        => ['Vadim Belman <vrurg@cpan.org>'],
     auth           => 'github:vrurg',


### PR DESCRIPTION
p6doc and Pod::To::Markdown are not used at all. META6 is used, but as an authoring dependency ( not the same as a build dependency ) for which there is no documented field ( yet ). Without this change anytime someone tries to install this module it will try to install META6 p6doc and Pod::To::Markdown despite them never being needed.